### PR TITLE
Upgrade masterfiles to support cfbs add directory

### DIFF
--- a/index.json
+++ b/index.json
@@ -181,7 +181,7 @@
       "tags": ["official", "base", "supported"],
       "repo": "https://github.com/cfengine/masterfiles",
       "by": "https://github.com/cfengine",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "commit": "5c7dc5b43088e259a94de4e5a9f17c0ce9781a0f",
       "steps": [
         "run ./autogen.sh",


### PR DESCRIPTION
services_autorun_bundles wasn't working by itself to support
cfbs add directory (CFE-3803).

Fix in masterfiles is from CFE-3799