### PR TITLE
Fixed github action schedule syntax

### DIFF
--- a/.github/workflows/all-modules-add-and-buildable.yaml
+++ b/.github/workflows/all-modules-add-and-buildable.yaml
@@ -6,8 +6,7 @@ name: Validate all modules in index can be added and built
 on:
   # Triggers the workflow on master every night at 3:15 am
   schedule:
-    branches: [ master ]
-    cron: '15 3 * * *'
+    - cron: '15 3 * * *'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The workflow files for that commit SHA and Git ref are inspected, and a new workflow run is triggered for any workflows that have on: values that match the triggering event.

The workflow runs on your repository's code at the same commit SHA and Git ref that triggered the event. When a workflow runs, GitHub sets the GITHUB_SHA (commit SHA) and GITHUB_REF (Git ref) environment variables in the runner environment. For more information, see "Using environment variables."

https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule