### PR TITLE
Revert "Bumped masterfiles to v3.18.1"

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -367,8 +367,8 @@
       "tags": ["supported", "base"],
       "repo": "https://github.com/cfengine/masterfiles",
       "by": "https://github.com/cfengine",
-      "version": "3.18.1",
-      "commit": "43f45bad841739fde496b5de9c01132311f6178b",
+      "version": "0.1.1",
+      "commit": "5c7dc5b43088e259a94de4e5a9f17c0ce9781a0f",
       "steps": [
         "run ./autogen.sh",
         "delete ./autogen.sh",


### PR DESCRIPTION
Reverts cfengine/build-index#124