### PR TITLE
inventory-kernel-settings-sysctl-current is experimental

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -141,7 +141,7 @@
     },
     "inventory-kernel-settings-sysctl-current": {
       "description": "Inventory sysctl settings current state.",
-      "tags": ["inventory", "kernel"],
+      "tags": ["inventory", "kernel", "experimental"],
       "repo": "https://github.com/nickanderson/cfengine-sysctl",
       "by": "https://github.com/nickanderson",
       "version": "1.0.0",


### PR DESCRIPTION
This module should be marked as experimental because it generates far too much inventory data to be reasonable to use as a human.