### PR TITLE
Fixed `compare_index_changes` workflow issue

### DIFF
--- a/.github/workflows/compare_index_changes.py
+++ b/.github/workflows/compare_index_changes.py
@@ -46,7 +46,7 @@ def compare_index_changes(new_index, old_index):
                 sys.exit(1)
 
         if new_module["commit"] != old_module["commit"]:
-            if new_module["version"] == old_module["commit"]:
+            if new_module["version"] == old_module["version"]:
                 print("Error: Attribute 'commit' was changed but not 'version'; in module '%s'" % module_name)
                 sys.exit(1)
 


### PR DESCRIPTION
Fixed issue where updating commit but not version was not detected by the `compare_index_changes` was not detected as an error.