### PR TITLE
Fixed missing check for prelink being available on the system

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -470,7 +470,7 @@
     },
     "prelinking-disabled": {
       "description": "Disable prelinking.",
-      "tags": ["security", "experimental"],
+      "tags": ["supported", "security"],
       "repo": "https://github.com/larsewi/cfengine-prelinking-disabled",
       "by": "https://github.com/larsewi",
       "version": "1.0.1",

--- a/cfbs.json
+++ b/cfbs.json
@@ -473,8 +473,8 @@
       "tags": ["security", "experimental"],
       "repo": "https://github.com/larsewi/cfengine-prelinking-disabled",
       "by": "https://github.com/larsewi",
-      "version": "1.0.0",
-      "commit": "9d2c8738caf1edc0c2f05a696c97358a8687f94a",
+      "version": "1.0.1",
+      "commit": "b39991902ae52745a097b5124c79c9e4c9f55404",
       "dependencies": ["autorun"],
       "steps": [
         "copy ./disable_prelinking.cf services/autorun/disable_prelinking.cf"


### PR DESCRIPTION
[issue](https://github.com/larsewi/cfengine-prelinking-disabled/issues/2)

Signed-off-by: larsewi <lars.erik.wik@northern.tech>