### PR TITLE
Update the tmp-nosuid module to version 0.0.2

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -757,8 +757,8 @@
       "tags": ["supported", "security", "compliance"],
       "repo": "https://github.com/vpodzime/cfengine-security-hardening",
       "by": "https://github.com/vpodzime",
-      "version": "0.0.1",
-      "commit": "c7ea31a59007fc2e8909d9c54839e9753f1b06d6",
+      "version": "0.0.2",
+      "commit": "5be7c3ef332138b5717231d289bda59449b66d5c",
       "subdirectory": "tmp-nosuid",
       "dependencies": ["autorun"],
       "steps": ["copy ./tmp_nosuid.cf services/autorun/tmp_nosuid.cf"]


### PR DESCRIPTION
A new version that also manages fstab or the /tmp mount unit.