### PR TITLE
Update the masterfiles module to new version with prepare.sh

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -483,13 +483,10 @@
       "tags": ["supported", "base"],
       "repo": "https://github.com/cfengine/masterfiles",
       "by": "https://github.com/cfengine",
-      "version": "0.2.0",
-      "commit": "1e24c2d6f5a6def24d0c14e99203866fec554a7c",
+      "version": "0.3.0",
+      "commit": "f3a8f65e77428a6ab9d62c34057a7ace6ae54ce9",
       "steps": [
-        "run ./autogen.sh",
-        "delete ./autogen.sh",
-        "run ./cfbs/cleanup.sh",
-        "delete ./cfbs/cleanup.sh",
+        "run ./prepare.sh -y",
         "copy ./ ./"
       ]
     },

--- a/cfbs.json
+++ b/cfbs.json
@@ -485,10 +485,7 @@
       "by": "https://github.com/cfengine",
       "version": "0.3.0",
       "commit": "f3a8f65e77428a6ab9d62c34057a7ace6ae54ce9",
-      "steps": [
-        "run ./prepare.sh -y",
-        "copy ./ ./"
-      ]
+      "steps": ["run ./prepare.sh -y", "copy ./ ./"]
     },
     "migrate2rocky": {
       "description": "Unattended migration of CentOS 8 hosts to Rocky Linux",


### PR DESCRIPTION
Since cfengine/masterfiles@f3a8f65e77428 there's a new script
that converts a directory with freshly cloned MPF into a
ready-to-use masterfiles directory.

Ticket: CFE-3872