### PR TITLE
Bumped lynis module version to 0.2.0

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -471,8 +471,8 @@
       "tags": ["security", "compliance", "experimental"],
       "repo": "https://github.com/nickanderson/cfengine-lynis",
       "by": "https://github.com/nickanderson",
-      "version": "0.1.3",
-      "commit": "086b0d305b96f44d96f50c4468242058742538af",
+      "version": "0.2.0",
+      "commit": "38b2f7f5e2b047055ce33c8dbb4978ab73319e94",
       "steps": [
         "copy policy/main.cf services/lynis/main.cf",
         "json cfbs/def.json def.json"


### PR DESCRIPTION
Several improvements here:
- Avoid ugly inform log about not being able to hash file before it's downloaded
- Fall back to wget if curl is not available
- Default version of lynis now 3.0.7 (current latest)
- Moved lynis scan info output to verbose mode