### PR TITLE
Bumped ssh-permit-empty-passwords-no to v1.0.4

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -658,8 +658,8 @@
       "tags": ["security", "ssh", "experimental"],
       "repo": "https://github.com/nickanderson/cfengine-security-hardening",
       "by": "https://github.com/nickanderson",
-      "version": "1.0.3",
-      "commit": "124b01041a3d45010ac20912338795e81e2a06fe",
+      "version": "1.0.4",
+      "commit": "705cd6a9c90b691b78a18876f1980d4d16fc9b1c",
       "subdirectory": "./ssh-permit-empty-passwords-no/",
       "dependencies": ["library-sshd-config"],
       "steps": [


### PR DESCRIPTION
https://github.com/nickanderson/cfengine-security-hardening/commits/master/ssh-permit-empty-passwords-no