### PR TITLE
ENT-8849: Bumped compliance-report-imports to version 0.0.6

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -58,8 +58,8 @@
       "tags": ["experimental", "cfengine-enterprise"],
       "repo": "https://github.com/nickanderson/cfengine-security-hardening",
       "by": "https://github.com/nickanderson",
-      "version": "0.0.5",
-      "commit": "4ff5dbdecd046c79086629911221c68fe571ff62",
+      "version": "0.0.6",
+      "commit": "6f6996bc36c07c91bcf9da9276d434cc0426ee97",
       "subdirectory": "./compliance-report-imports",
       "dependencies": ["autorun"],
       "steps": ["copy ./compliance-report-imports.cf services/autorun/"]


### PR DESCRIPTION
This version fixes the source path to copy from when installing compliance
reports. Now the source is masterdir, not inputs.

Ticket: ENT-8849
Changelog: None