### PR TITLE
ENT-8952: Released masterfiles 3.20.0

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -483,8 +483,8 @@
       "tags": ["supported", "base"],
       "repo": "https://github.com/cfengine/masterfiles",
       "by": "https://github.com/cfengine",
-      "version": "3.18.2",
-      "commit": "a87b7fea6f7a88808b327730a4ba784a3dc664eb",
+      "version": "3.20.0",
+      "commit": "ae9c8cbf7ec280bc752cff096a14abaf4d0d2ed6",
       "steps": ["run ./prepare.sh -y", "copy ./ ./"]
     },
     "migrate2rocky": {


### PR DESCRIPTION
Note, this is presumptive. Release tags have not been made at the time of this writing. Please double check.