### PR TITLE
Bumped lynis to 0.3.0

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -471,8 +471,8 @@
       "tags": ["security", "compliance", "experimental"],
       "repo": "https://github.com/nickanderson/cfengine-lynis",
       "by": "https://github.com/nickanderson",
-      "version": "0.2.1",
-      "commit": "f1bf2c0c9f6ccca54085f05e914351aad8e52852",
+      "version": "0.3.0",
+      "commit": "029a34701c165b4a43e30da7088548e26658516e",
       "steps": [
         "copy policy/main.cf services/lynis/main.cf",
         "json cfbs/def.json def.json"


### PR DESCRIPTION
- Default version of Lynis bumped to 3.0.8
- Variables used to configured desired version of Lynis have changed, no longer looking for variables in `default:def`.
- New Inventory attributes
  - CISOfy Lynis date scan completed
  - CISOfy Lynis days since scan completed

https://github.com/nickanderson/cfengine-lynis/compare/f1bf2c0c9f6ccca54085f05e914351aad8e52852..029a34701c165b4a43e30da7088548e26658516e