### PR TITLE
Added inventory-local-users-unhashed-password version 1.0.0

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -485,6 +485,21 @@
         "json cfbs/def.json def.json"
       ]
     },
+    "inventory-local-users-unhashed-password": {
+      "description": "Adds reporting data (inventory) for local users not using hashed passwords.",
+      "tags": ["supported", "inventory", "security", "compliance"],
+      "repo": "https://github.com/cfengine/modules",
+      "by": "https://github.com/nickanderson",
+      "version": "1.0.0",
+      "commit": "057f24c8e96ef5504779d45f3f8a19907ccf0b32",
+      "subdirectory": "security/inventory-local-users-unhashed-password/",
+      "dependencies": ["library-parsed-local-users"],
+      "steps": [
+        "copy policy/main.cf services/cfbs/inventory-local-users-unhashed-password/",
+        "policy_files services/cfbs/inventory-local-users-unhashed-password/",
+        "bundles inventory_local_users_unhashed_password:main"
+      ]
+    },
     "inventory-openssl-versions": {
       "description": "Adds an inventory attribute containing all versions of OpenSSL found on the system.",
       "tags": ["inventory", "security", "experimental"],


### PR DESCRIPTION
```
$ cfbs --force --non-interactive init
$ cfbs --non-interactive remove masterfiles
$ cfbs --non-interactive add https://github.com/cfengine/masterfiles@0de3ef61988670dbf0afa8b29fe4d269ead4c655 masterfiles
$ cfbs --non-interactive add https://github.com/cfengine/modules inventory-local-users-unhashed-password
$ cfbs status
Name:        Example project
Description: Example description
File:        cfbs.json

Modules:
001 masterfiles                             @ 0de3ef61988670dbf0afa8b29fe4d269ead4c655 (Downloaded)
002 library-parsed-local-users              @ ede282c34083ab807543aa734b1142228ab98993 (Downloaded)
003 inventory-local-users-unhashed-password @ 057f24c8e96ef5504779d45f3f8a19907ccf0b32 (Downloaded)
```

See example in module readme for setting up a couple of users that will trigger inventory.