### PR TITLE
ENT-9736: Updated compliance-report-os-is-vendor-supported to version 0.0.4

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -71,8 +71,8 @@
       "tags": ["experimental", "compliance-report", "cfengine-enterprise"],
       "repo": "https://github.com/nickanderson/cfengine-security-hardening",
       "by": "https://github.com/nickanderson",
-      "version": "0.0.3",
-      "commit": "1b9d2fab3d3fd43fae3d34f864c8cfa4574b01b4",
+      "version": "0.0.4",
+      "commit": "d828be6de5b73b0058e4367c2ab09bda1cf035ca",
       "subdirectory": "./compliance-report-os-is-vendor-supported",
       "dependencies": ["compliance-report-imports"],
       "steps": [


### PR DESCRIPTION
- Updated supported operating systems
  - Fixed description of Supported Debian (removed Debian 9)
  - Fixed description of Supported Ubuntu (added Ubuntu 22)
  - Removed RHEL 7
  - Added RHEL 9
  - Removed CentOS 7
  - Removed Windows 2016
  - Added Windows 11, 2022
- Adjusted OS is reported to not consider Unknown OS as reported

https://github.com/nickanderson/cfengine-security-hardening/compare/1b9d2fab3d3fd43fae3d34f864c8cfa4574b01b4..d828be6de5b73b0058e4367c2ab09bda1cf035ca

Ticket: ENT-9736
Changelog: Title