### PR TITLE
Update custom promise type modules from cfengine/modules

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -664,8 +664,8 @@
       "tags": ["supported", "library"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/cfengine",
-      "version": "0.1.1",
-      "commit": "c3b7329b240cf7ad062a0a64ee8b607af2cb912a",
+      "version": "0.2.1",
+      "commit": "231bb9ccd64e0402e82004c59107e4caafa17051",
       "subdirectory": "libraries/python",
       "steps": ["copy cfengine.py modules/promises/"]
     },
@@ -779,8 +779,8 @@
       "tags": ["supported", "promise-type"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/tranchitella",
-      "version": "0.1.1",
-      "commit": "c3b7329b240cf7ad062a0a64ee8b607af2cb912a",
+      "version": "0.2.1",
+      "commit": "231bb9ccd64e0402e82004c59107e4caafa17051",
       "subdirectory": "promise-types/ansible",
       "dependencies": ["library-for-promise-types-in-python"],
       "steps": [
@@ -807,8 +807,8 @@
       "tags": ["supported", "promise-type", "experimental"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/larsewi",
-      "version": "0.1.3",
-      "commit": "fd255fbdcc6cac0521ab8de2c543c684fadb16fa",
+      "version": "0.2.3",
+      "commit": "231bb9ccd64e0402e82004c59107e4caafa17051",
       "subdirectory": "promise-types/groups",
       "dependencies": ["library-for-promise-types-in-python"],
       "steps": [
@@ -821,8 +821,8 @@
       "tags": ["supported", "promise-type", "http"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/vpodzime",
-      "version": "1.1.0",
-      "commit": "501e96673621d6b9754f8a5c32bf2ee509e6bf5b",
+      "version": "2.0.0",
+      "commit": "231bb9ccd64e0402e82004c59107e4caafa17051",
       "subdirectory": "promise-types/http",
       "dependencies": ["library-for-promise-types-in-python"],
       "steps": [


### PR DESCRIPTION
A new 'meta' argument was added to the
validate/evaluate_promise() functions so versions need to be bumped and commit SHAs updated.