### PR TITLE
ENT-10032: Added masterfiles 3.21.1

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -832,8 +832,8 @@
       "tags": ["supported", "base"],
       "repo": "https://github.com/cfengine/masterfiles",
       "by": "https://github.com/cfengine",
-      "version": "3.18.4",
-      "commit": "c92106b72ac9a9f12e412df7ecba1ea22bcb373a",
+      "version": "3.21.1",
+      "commit": "379c69aa71ab3069b2ef1c0cca526192fa77b864",
       "steps": ["run ./prepare.sh -y", "copy ./ ./"]
     },
     "migrate2rocky": {


### PR DESCRIPTION
Masterfiles did not change between 3.21.0 and 3.21.1, so the commit is the same,
but the versioned artifacts differ in the actual version strings.