### PR TITLE
Ensure we fetch tags before building a module

### DIFF
--- a/.github/workflows/mirroring.yml
+++ b/.github/workflows/mirroring.yml
@@ -15,6 +15,8 @@ jobs:
         steps:
             - name: Checks-out repository
               uses: actions/checkout@v2
+            - name: Get tags
+              run: git fetch --tags origin
 
             - name: Setup Node.js environment
               uses: actions/setup-node@v2.4.1

--- a/.github/workflows/mirroring.yml
+++ b/.github/workflows/mirroring.yml
@@ -15,8 +15,8 @@ jobs:
         steps:
             - name: Checks-out repository
               uses: actions/checkout@v2
-            - name: Get tags
-              run: git fetch --tags origin
+              with:
+                fetch-depth: 0
 
             - name: Setup Node.js environment
               uses: actions/setup-node@v2.4.1


### PR DESCRIPTION
Some modules, notably masterfiles, rely on git to determine version numbers.