### PR TITLE
ENT-10331: Fixed policy version for 3.22.0

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -896,7 +896,7 @@
       "readme_url": "modules/masterfiles/ca4a227706b89313bc66b6eb6fc839628bea6a3a.md",
       "readme_sha256": "5290c619aef65139e7378b75439b8668756fb91df1ee6a20d7627a00a24c2407",
       "steps": [
-        "run ./prepare.sh -y",
+        "run EXPLICIT_VERSION=3.22.0 ./prepare.sh -y",
         "copy ./ ./"
       ],
       "subdirectory": "",


### PR DESCRIPTION
This changes sets EXPLICIT_VERSION so that we do not end up with commit shas as
part of the version strings in the built policy.
For example, we get "CFEngine Standalone Self Upgrade 3.22.0" instead of
"CFEngine Standalone Self Upgrade 3.22.0a.2708fa941".

Ticket: ENT-10331
Changelog: None