### PR TITLE
ENT-10745: conditional-installer: Fixed input key name

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -110,7 +110,7 @@
           "label": "Install",
           "subtype": [
             {
-              "key": "name",
+              "key": "packages",
               "type": "string",
               "label": "Package(s)",
               "question": "Package(s) to install"

--- a/cfbs.json
+++ b/cfbs.json
@@ -89,7 +89,7 @@
       "subdirectory": "security/conditional-installer",
       "steps": [
         "copy main.cf services/cfbs/modules/conditional-installer/main.cf",
-        "input conditional-installer/input.json def.json",
+        "input ./input.json def.json",
         "bundles conditional_installer:main",
         "policy_files services/cfbs/modules/conditional-installer/main.cf"
       ],


### PR DESCRIPTION
See that the policy looks for the `packages` key, not the `name` key.

https://github.com/cfengine/modules/blob/26e0151745b342dbd8b5206c17c3e075622cec77/security/conditional-installer/main.cf#L27