### PR TITLE
ENT-11210: Bumped compliance-report-imports to 0.0.10

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -100,8 +100,8 @@
       "tags": ["experimental", "cfengine-enterprise"],
       "repo": "https://github.com/nickanderson/cfengine-security-hardening",
       "by": "https://github.com/nickanderson",
-      "version": "0.0.9",
-      "commit": "019880c60e1bfbcecc8bf9d91f98c1443772354b",
+      "version": "0.0.10",
+      "commit": "1afe01806fb18e764f904eda6e3cc49f9c9ff3dd",
       "subdirectory": "compliance-report-imports",
       "dependencies": ["autorun"],
       "steps": ["copy ./compliance-report-imports.cf services/autorun/"]


### PR DESCRIPTION
The related change: https://github.com/nickanderson/cfengine-security-hardening/commit/1afe01806fb18e764f904eda6e3cc49f9c9ff3dd