### PR TITLE
Patch releases for the promise type modules from cfengine/modules

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -1016,8 +1016,8 @@
       "tags": ["supported", "promise-type"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/tranchitella",
-      "version": "0.2.2",
-      "commit": "70afe61739bbb2cfc205dc0b604fbdda96b6be43",
+      "version": "0.2.3",
+      "commit": "813fb3d172c8db5642ef69cd5e8ef32b264ef275",
       "subdirectory": "promise-types/git",
       "dependencies": ["library-for-promise-types-in-python"],
       "steps": [

--- a/cfbs.json
+++ b/cfbs.json
@@ -1044,8 +1044,8 @@
       "tags": ["supported", "promise-type", "http"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/vpodzime",
-      "version": "2.0.0",
-      "commit": "70afe61739bbb2cfc205dc0b604fbdda96b6be43",
+      "version": "2.0.1",
+      "commit": "813fb3d172c8db5642ef69cd5e8ef32b264ef275",
       "subdirectory": "promise-types/http",
       "dependencies": ["library-for-promise-types-in-python"],
       "steps": [

--- a/cfbs.json
+++ b/cfbs.json
@@ -988,8 +988,8 @@
       "tags": ["supported", "promise-type"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/tranchitella",
-      "version": "0.2.1",
-      "commit": "70afe61739bbb2cfc205dc0b604fbdda96b6be43",
+      "version": "0.2.2",
+      "commit": "813fb3d172c8db5642ef69cd5e8ef32b264ef275",
       "subdirectory": "promise-types/ansible",
       "dependencies": ["library-for-promise-types-in-python"],
       "steps": [

--- a/cfbs.json
+++ b/cfbs.json
@@ -1030,8 +1030,8 @@
       "tags": ["supported", "promise-type", "experimental"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/larsewi",
-      "version": "0.2.3",
-      "commit": "70afe61739bbb2cfc205dc0b604fbdda96b6be43",
+      "version": "0.2.4",
+      "commit": "813fb3d172c8db5642ef69cd5e8ef32b264ef275",
       "subdirectory": "promise-types/groups",
       "dependencies": ["library-for-promise-types-in-python"],
       "steps": [

--- a/cfbs.json
+++ b/cfbs.json
@@ -1058,8 +1058,8 @@
       "tags": ["supported", "promise-type", "systemd"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/tranchitella",
-      "version": "0.2.2",
-      "commit": "70afe61739bbb2cfc205dc0b604fbdda96b6be43",
+      "version": "0.2.3",
+      "commit": "813fb3d172c8db5642ef69cd5e8ef32b264ef275",
       "subdirectory": "promise-types/systemd",
       "dependencies": ["library-for-promise-types-in-python"],
       "steps": [

--- a/cfbs.json
+++ b/cfbs.json
@@ -809,8 +809,8 @@
       "tags": ["supported", "library"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/cfengine",
-      "version": "0.2.1",
-      "commit": "70afe61739bbb2cfc205dc0b604fbdda96b6be43",
+      "version": "0.2.2",
+      "commit": "813fb3d172c8db5642ef69cd5e8ef32b264ef275",
       "subdirectory": "libraries/python",
       "steps": ["copy cfengine.py modules/promises/"]
     },


### PR DESCRIPTION
Mostly just to align the meta vs metadata parameter name, and cleaned up their READMEs.

- **Upgraded library-for-promise-types-in-python to version 0.2.2**
- **Upgraded promise-type-ansible to version 0.2.2**
- **Upgraded promise-type-git to version 0.2.3**
- **Upgraded promise-type-groups to version 0.2.4**
- **Upgraded promise-type-http to version 2.0.1**
- **Upgraded promise-type-systemd to version 0.2.3**
