### PR TITLE
Bumped Lynis module version from 3.1.1 to 3.1.1-2

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -883,11 +883,51 @@
       "tags": ["security", "compliance"],
       "repo": "https://github.com/nickanderson/cfengine-lynis",
       "by": "https://github.com/nickanderson",
-      "version": "3.1.1",
-      "commit": "70bdf7be29c890d3bf162a8fe993e8d12eb61388",
+      "version": "3.1.1-2",
+      "commit": "4db6d515c45873a9f3fa7ce78ece593027464b64",
       "steps": [
         "copy policy/main.cf services/lynis/main.cf",
-        "json cfbs/def.json def.json"
+        "json cfbs/def.json def.json",
+        "input ./input.json def.json"
+      ],
+      "input": [
+        {
+          "type": "string",
+          "namespace": "lynis",
+          "bundle": "globals",
+          "variable": "version",
+          "label": "Lynis version",
+          "question": "What version of Lynis should be used?",
+          "default": "3.1.1"
+        },
+        {
+          "type": "string",
+          "namespace": "lynis",
+          "bundle": "globals",
+          "variable": "tar_url",
+          "label": "Tarball url",
+          "question": "Where should clients download lynis from (http/https)",
+          "default": "https://downloads.cisofy.com/lynis/lynis-$(version).tar.gz",
+          "comment": "Some may want to self host the tarball within their own infrastructure. This provides an easy way to do that. Note, the archive should be named for the version of Lynis selected."
+        },
+        {
+          "type": "string",
+          "namespace": "lynis",
+          "bundle": "globals",
+          "variable": "archive_hash",
+          "label": "Hash of the tarball",
+          "question": "What is the hash of the tarball?",
+          "default": "d72f4ee7325816bb8dbfcf31eb104207b9fe58a2493c2a875373746a71284cc3"
+        },
+        {
+          "type": "string",
+          "namespace": "lynis",
+          "bundle": "globals",
+          "variable": "hash_type",
+          "label": "Hash type to verify",
+          "question": "What hashing algorithm should be used to verify the Lynis script?",
+          "default": "sha256"
+        }
       ]
     },
     "maintainers-in-motd": {


### PR DESCRIPTION
This version change introduces module input. The module input defaults match the
policy defaults so the behavior remains the same if module input is provided or
not.

This version does change a couple variables to be overridable via Augments:

- lynis:globals.hash_type
- lynis:global.tar_url