### PR TITLE
Replaced deprecated set-output with GITHUB_OUTPUT in the s3 mirroring action

### DIFF
--- a/.github/workflows/mirroring.yml
+++ b/.github/workflows/mirroring.yml
@@ -67,7 +67,7 @@ jobs:
               run: |
                 body=$(cat commitMsg.txt)
                 body="${body//$'\n'/'%0A'}"
-                echo ::set-output name=body::$body
+                echo "body=$body" >> $GITHUB_OUTPUT
 
             - name: Create Pull Request
               if: hashFiles('git_diff_exists') != ''


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/