### PR TITLE
Set default masterfiles back to latest LTS: 3.24.2

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -963,10 +963,10 @@
       "tags": ["supported", "base"],
       "repo": "https://github.com/cfengine/masterfiles",
       "by": "https://github.com/cfengine",
-      "version": "3.26.0",
-      "commit": "73962490485f5746cbc037a88e2ee24c87ae0b5e",
+      "version": "3.24.2",
+      "commit": "5c49f1ed1c3a4ecfc46b4b61296ff5dd38991f33",
       "steps": [
-        "run EXPLICIT_VERSION=3.26.0 EXPLICIT_RELEASE=1 ./prepare.sh -y",
+        "run EXPLICIT_VERSION=3.24.2 EXPLICIT_RELEASE=1 ./prepare.sh -y",
         "copy ./ ./"
       ]
     },


### PR DESCRIPTION
This reverts commit 44476a1d56bf5196e6609392aac6097acebe50d9.
