### PR TITLE
docker_compose update to 1.3.0

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -1132,12 +1132,13 @@
       "tags": ["promise-type", "docker", "experimental"],
       "repo": "https://github.com/basvandervlies/scl_modules",
       "by": "https://github.com/basvandervlies",
-      "version": "1.2.2",
-      "commit": "2b78dea5b274f86d365e6f9e724a3a4d2bd8e775",
+      "version": "1.3.0",
+      "commit": "5014cc656f66e3139b4ce10702c09cd6c8619cee",
       "subdirectory": "promise-types/docker_compose",
       "dependencies": ["library-for-promise-types-in-bash"],
       "steps": [
         "copy docker_compose.sh modules/promises/docker_compose.sh",
+        "replace 1 0.0.0 1.3.0 modules/promises/docker_compose.sh",
         "append enable.cf services/init.cf"
       ]
     },


### PR DESCRIPTION
with docker compose you can start multiple containers. Now we detect if one or multiple has been stopped