### PR TITLE
Bumped versions of affected modules after fixing pyright issues

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -1267,8 +1267,8 @@
       "tags": ["promise-type", "experimental"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/victormlg",
-      "version": "0.0.3",
-      "commit": "258304b1783287d06d13e6851951c95f9b7facb2",
+      "version": "0.0.4",
+      "commit": "679c6c0b18cdb517c7595b1701c3707f47106da5",
       "subdirectory": "promise-types/json",
       "dependencies": ["library-for-promise-types-in-python"],
       "steps": [

--- a/cfbs.json
+++ b/cfbs.json
@@ -902,8 +902,8 @@
       "tags": ["supported", "library"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/cfengine",
-      "version": "0.3.0",
-      "commit": "258304b1783287d06d13e6851951c95f9b7facb2",
+      "version": "0.3.1",
+      "commit": "679c6c0b18cdb517c7595b1701c3707f47106da5",
       "subdirectory": "libraries/python",
       "steps": [
         "copy cfengine_module_library.py modules/promises/cfengine_module_library.py",

--- a/cfbs.json
+++ b/cfbs.json
@@ -1297,8 +1297,8 @@
       "tags": ["supported", "promise-type", "systemd"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/tranchitella",
-      "version": "0.2.4",
-      "commit": "258304b1783287d06d13e6851951c95f9b7facb2",
+      "version": "0.2.5",
+      "commit": "679c6c0b18cdb517c7595b1701c3707f47106da5",
       "subdirectory": "promise-types/systemd",
       "dependencies": ["library-for-promise-types-in-python"],
       "steps": [

--- a/cfbs.json
+++ b/cfbs.json
@@ -1194,8 +1194,8 @@
       "tags": ["supported", "promise-type"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/tranchitella",
-      "version": "0.2.3",
-      "commit": "dcb2aa283a48bcc61011ad0eea8042a2185b1adc",
+      "version": "0.2.4",
+      "commit": "679c6c0b18cdb517c7595b1701c3707f47106da5",
       "subdirectory": "promise-types/ansible",
       "dependencies": ["library-for-promise-types-in-python"],
       "steps": [


### PR DESCRIPTION
- **library-for-promise-types-in-python: bumped to 0.3.1**
- **promise-type-ansible: bumped to 0.2.4**
- **promise-type-systemd: bumped to 0.2.5**
- **promise-type-json: bumped to 0.0.4**
