### PR TITLE
Bump command-dispatcher to 0.0.4, fix policy_files path

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -20,11 +20,11 @@
       "repo": "https://github.com/cfengine/modules",
       "subdirectory": "management/command-dispatcher",
       "by": "https://github.com/simonthalvorsen",
-      "version": "0.0.3",
-      "commit": "5ccc1f8b40d1b6b04525e768374d096d1ec59ec3",
+      "version": "0.0.4",
+      "commit": "6310f37e61a62a1bdf5f6fd5e907cb6ae3382ce9",
       "steps": [
         "copy main.cf services/cfbs/modules/command-dispatcher/main.cf",
-        "policy_files services/cfbs/command-dispatcher/main.cf",
+        "policy_files services/cfbs/modules/command-dispatcher/main.cf",
         "bundles command_dispatcher:main",
         "input ./input.json def.json"
       ],


### PR DESCRIPTION
## Problem

The `command-dispatcher` module's `steps` in the index have mismatched target paths:

```
copy main.cf        services/cfbs/modules/command-dispatcher/main.cf
policy_files        services/cfbs/command-dispatcher/main.cf   # <-- missing /modules/
```

`copy` installs `main.cf` under `services/cfbs/modules/command-dispatcher/`, but `policy_files` registers `services/cfbs/command-dispatcher/main.cf`. The generated masterfiles therefore reference a policy file that was never copied there, so the agent fails to load it. This has been broken since v0.0.1 (all of 0.0.1–0.0.3).

## Fix

The path was already corrected upstream in cfengine/modules commit `6310f37` ("fix wrong path command-dispatcher policy_files-value"), but the index still pins the broken v0.0.3. This bumps the index entry to **0.0.4** at commit `6310f37` and aligns the `policy_files` step under `services/cfbs/modules/` to match `copy`.

## Verification

Both steps now target `services/cfbs/modules/command-dispatcher/main.cf`, matching the documented cfbs module install convention.