### PR TITLE
Downgraded actions/checkout to v4 in bump module action

### DIFF
--- a/.github/workflows/bump_module.yml
+++ b/.github/workflows/bump_module.yml
@@ -27,7 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checks-out repository
-        uses: actions/checkout@v7
+        # v7 is not compatible with cfengine/create-pull-request
+        uses: actions/checkout@v4
 
       - name: Install cfbs
         run: pip3 install cfbs


### PR DESCRIPTION
`actions/checkout` v6 and later configure an HTTP Authorization header that collides with the one `cfengine/create-pull-request` sets, so git sends two and GitHub rejects the request:

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/cfengine/build-index/': The requested URL returned error: 400
```

v4 is what `mirroring.yml` already pairs with the same action. Upstream reports: peter-evans/create-pull-request#4228, peter-evans/create-pull-request#4272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)