### PR TITLE
Use a pr- prefixed branch in bump module action

### DIFF
--- a/.github/workflows/bump_module.yml
+++ b/.github/workflows/bump_module.yml
@@ -59,4 +59,5 @@ jobs:
           reviewers: |
             olehermanse
             nickanderson
-          branch: bump/${{ inputs.module }}
+          # The "pr-" prefix is exempt from the ruleset blocking branch creation
+          branch: pr-bump-${{ inputs.module }}


### PR DESCRIPTION
Branch creation is blocked by a ruleset for everyone but organization admins, and "pr-*" is one of its exempted patterns.
