### PR TITLE
Bumped module 'inventory-fwupd' from version 0.1.0 to 0.1.1

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -911,8 +911,8 @@
       "tags": ["inventory", "monitoring", "hardware", "security"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/nickanderson",
-      "version": "0.1.0",
-      "commit": "6d4d5d1da1866eef5fdd38601f519acbfb531d69",
+      "version": "0.1.1",
+      "commit": "709caa244087113854c9a8fdaff04c2c54a35587",
       "subdirectory": "inventory/inventory-fwupd",
       "steps": [
         "copy policy.cf services/cfbs/modules/inventory-fwupd/policy.cf",


### PR DESCRIPTION
Picks up cfengine/modules#154, which collects the fwupd device list with `fwupdmgr get-devices --json` instead of fwupd's often zero-length `/var/cache/fwupd/devices.json`.