### PR TITLE
Bumped fwupd modules for the HSI pass/fail list change

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -174,8 +174,8 @@
       "tags": ["reporting", "compliance", "security", "hardware"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/nickanderson",
-      "version": "0.1.1",
-      "commit": "1d55ad3666d2df4262ce1c5ee8d70a7c72a13944",
+      "version": "0.2.0",
+      "commit": "883a37826bb32122097d214eae847e3c07174fbf",
       "subdirectory": "reporting/compliance-report-fwupd",
       "dependencies": ["inventory-fwupd"],
       "steps": [
@@ -911,8 +911,8 @@
       "tags": ["inventory", "monitoring", "hardware", "security"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/nickanderson",
-      "version": "0.1.2",
-      "commit": "1d55ad3666d2df4262ce1c5ee8d70a7c72a13944",
+      "version": "0.2.0",
+      "commit": "883a37826bb32122097d214eae847e3c07174fbf",
       "subdirectory": "inventory/inventory-fwupd",
       "steps": [
         "copy policy.cf services/cfbs/modules/inventory-fwupd/policy.cf",
@@ -1143,8 +1143,8 @@
       "tags": ["management", "hardware", "security"],
       "repo": "https://github.com/cfengine/modules",
       "by": "https://github.com/nickanderson",
-      "version": "0.1.1",
-      "commit": "1d55ad3666d2df4262ce1c5ee8d70a7c72a13944",
+      "version": "0.1.2",
+      "commit": "883a37826bb32122097d214eae847e3c07174fbf",
       "subdirectory": "management/manage-fwupd",
       "dependencies": ["inventory-fwupd"],
       "steps": [


### PR DESCRIPTION
inventory-fwupd 0.2.0, compliance-report-fwupd 0.2.0, manage-fwupd 0.1.2 — all pinned to `883a37826bb32122097d214eae847e3c07174fbf`.

inventory-fwupd replaces its per-check HSI inventory attributes with the `Firmware HSI failing` and `Firmware HSI passing` lists, and compliance-report-fwupd's conditions are rewritten to match against them, so both get a minor bump. manage-fwupd only changed its README.

Follows cfengine/modules#156.